### PR TITLE
Custom loader replacer

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,46 @@ module.exports = {
 
 ### Available Options
 
-| Option Name            | Description                                                                         | Available Values                                                              | Default Value                           |
-| ---------------------- | ----------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | --------------------------------------- |
-| `optimizationLevel`    | Level of build speed optimization (See [Optimization Levels](#optimization-levels)) | `0` ~ `3`                                                                     | `1`                                     |
-| `esbuildMinifyOptions` | Options for esbuild via `ESBuildMinifyPlugin`                                       | object ([Docs](https://github.com/privatenumber/esbuild-loader#minifyplugin)) | `{ target: "es2015" }`                  |
-| `removeProgressPlugin` | Whether to remove `ProgressPlugin`                                                  | boolean                                                                       | `process.env.NODE_ENV === "production"` |
-| `disableSourceMap`     | Whether to disable source map generation                                            | boolean                                                                       | `process.env.NODE_ENV === "production"` |
+| Option Name            | Description                                                                         | Available Values                                                              | Default Value                                                                                                    |
+| ---------------------- | ----------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `optimizationLevel`    | Level of build speed optimization (See [Optimization Levels](#optimization-levels)) | `0` ~ `3`                                                                     | `1`                                                                                                              |
+| `esbuildMinifyOptions` | Options for esbuild via `ESBuildMinifyPlugin`                                       | object ([Docs](https://github.com/privatenumber/esbuild-loader#minifyplugin)) | `{ target: "es2015" }`                                                                                           |
+| `removeProgressPlugin` | Whether to remove `ProgressPlugin`                                                  | boolean                                                                       | `process.env.NODE_ENV === "production"`                                                                          |
+| `disableSourceMap`     | Whether to disable source map generation                                            | boolean                                                                       | `process.env.NODE_ENV === "production"`                                                                          |
+| `managerTranspiler`    | Manager Webpack loader configuration that will replace `babel-loader` with          | Object (loader config) or Function ([`LoaderReplacer`](#loader-replacer))     | Function returns a loader config object for `esbuild-loader` when Optimization Level >= 2, `undefined` otherwise |
+| `previewTranspiler`    | Preview Webpack loader configuration that will replace `babel-loader` with          | Object (loader config) or Function ([`LoaderReplacer`](#loader-replacer))     | Function returns a loader config object for `esbuild-loader` when Optimization Level >= 3, `undefined` otherwise |
+
+#### `LoaderReplacer`
+
+[`LoaderReplacer`](./src/webpack.ts) is a function that takes loader config object and rule then returns a new loader config object.
+Return `null` to remove the matching loader instead of to replace.
+
+```ts
+// Type Definition
+type LoaderReplacer = (
+  loader: webpack.RuleSetUseItem,
+  rule: webpack.RuleSetRule
+) => webpack.RuleSetUseItem | null;
+```
+
+```ts
+// Replace babel-loader with swc-loader in Preview Webpack
+{
+  previewTranspiler(loader, rule) {
+    return {
+      loader: "swc-loader",
+      options: {/* ... */}
+    }
+  }
+}
+
+// Simply remove babel-loader from Manager Webpack
+{
+  managerTranspiler() {
+    return null
+  }
+}
+```
 
 ### Optimization Levels
 

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -9,10 +9,10 @@
   },
   "devDependencies": {
     "@babel/core": "^7.12.16",
-    "@storybook/addon-actions": "^6.1.18",
-    "@storybook/addon-essentials": "^6.1.18",
-    "@storybook/addon-links": "^6.1.18",
-    "@storybook/react": "^6.1.18",
+    "@storybook/addon-actions": "^6.4.9",
+    "@storybook/addon-essentials": "^6.4.9",
+    "@storybook/addon-links": "^6.4.9",
+    "@storybook/react": "^6.4.9",
     "babel-loader": "^8.2.2",
     "esbuild-loader": "^2.9.1"
   },

--- a/src/transformers.ts
+++ b/src/transformers.ts
@@ -29,29 +29,29 @@ export const esbuildLoaderReplacer: LoaderReplacer = (loader, rule) => ({
  * Replace babel-loader with specified loader.
  * @param replacer Function that takes loader object (`RuleSetUseItem`) and rule (`RuleSetRule`) then returns a new loader object.
  */
-export const replaceBabelLoader = (replacer: LoaderReplacer) => (
-  config: webpack.Configuration
-): webpack.Configuration => {
-  return replaceLoader(
-    config,
-    (loader, rule) => {
-      switch (typeof loader) {
-        case "string":
-          return babelLoaderPattern.test(loader);
-        case "object":
-          return !!(
-            (isRuleAppliedTo(rule, "foo.js") ||
-              isRuleAppliedTo(rule, "foo.ts")) &&
-            loader.loader &&
-            babelLoaderPattern.test(loader.loader)
-          );
-        default:
-          return false;
-      }
-    },
-    replacer
-  );
-};
+export const replaceBabelLoader =
+  (replacer: LoaderReplacer) =>
+  (config: webpack.Configuration): webpack.Configuration => {
+    return replaceLoader(
+      config,
+      (loader, rule) => {
+        switch (typeof loader) {
+          case "string":
+            return babelLoaderPattern.test(loader);
+          case "object":
+            return !!(
+              (isRuleAppliedTo(rule, "foo.js") ||
+                isRuleAppliedTo(rule, "foo.ts")) &&
+              loader.loader &&
+              babelLoaderPattern.test(loader.loader)
+            );
+          default:
+            return false;
+        }
+      },
+      replacer
+    );
+  };
 
 export function removeProgressPlugin(
   config: webpack.Configuration,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,8 @@
 import { ESBuildMinifyPlugin } from "esbuild-loader";
 import type * as webpack from "webpack";
 
+import type { LoaderReplacer } from "./webpack";
+
 type MinifyOptions = NonNullable<
   ConstructorParameters<typeof ESBuildMinifyPlugin>[0]
 >;
@@ -28,6 +30,20 @@ export interface PresetOptions {
    * Defaults to `true` when `NODE_ENV=production` otherwise `false`.
    */
   disableSourceMap: boolean;
+
+  /**
+   * A function to replace `babel-loader` with custom webpack loader for Manager (Storybook UI, addons).
+   * Return `null` to remove `babel-loader` without replacement.
+   * Defaults to a function that replace with `esbuild-loader` when `optimizationLevel` >= 2, `undefined` otherwise.
+   */
+  managerTranspiler?: LoaderReplacer | webpack.RuleSetUseItem;
+
+  /**
+   * A function to replace babel-loader with custom webpack loader for Preview (iframe, your code)
+   * Return `null` to remove `babel-loader` without replacement.
+   * Defaults to a function that replace with `esbuild-loader` when `optimizationLevel` >= 3, `undefined` otherwise.
+   */
+  previewTranspiler?: LoaderReplacer | webpack.RuleSetUseItem;
 }
 
 export type Transformer = (

--- a/src/webpack.spec.ts
+++ b/src/webpack.spec.ts
@@ -1,6 +1,45 @@
-import { Configuration, Plugin, ProgressPlugin, RuleSetUseItem } from "webpack";
+import {
+  Configuration,
+  Plugin,
+  ProgressPlugin,
+  RuleSetRule,
+  RuleSetUseItem,
+} from "webpack";
 
-import { removePlugin, replaceLoader } from "./webpack";
+import { isRuleAppliedTo, removePlugin, replaceLoader } from "./webpack";
+
+describe("#isRuleAppliedTo", () => {
+  it("Should work with string rule", () => {
+    expect(isRuleAppliedTo({ test: "foo.ts" }, "foo.ts")).toEqual(true);
+  });
+
+  it("Should return false when the input string not started with the given string", () => {
+    expect(isRuleAppliedTo({ test: "/dir/foo.ts" }, "foo.ts")).toEqual(false);
+  });
+
+  it("Should work with RegExp rule", () => {
+    expect(isRuleAppliedTo({ test: /\.ts$/ }, "foo.ts")).toEqual(true);
+  });
+
+  it("Should work with function rule", () => {
+    expect(
+      isRuleAppliedTo({ test: (name) => name === "foo.ts" }, "foo.ts")
+    ).toEqual(true);
+    expect(
+      isRuleAppliedTo({ test: (name) => name === "bar.ts" }, "foo.ts")
+    ).toEqual(false);
+  });
+
+  it("Should work with multiple rules", () => {
+    const testRule: RuleSetRule = {
+      test: [/\.ts$/, (path) => path.includes("foo")],
+    };
+
+    expect(isRuleAppliedTo(testRule, "bar.ts")).toEqual(true);
+    expect(isRuleAppliedTo(testRule, "foo.js")).toEqual(true);
+    expect(isRuleAppliedTo(testRule, "baz.rs")).toEqual(false);
+  });
+});
 
 describe("#removePlugin", () => {
   class TestPlugin implements Plugin {

--- a/src/webpack.ts
+++ b/src/webpack.ts
@@ -97,7 +97,7 @@ export function removePlugin(
 }
 
 type LoaderTester = (loader: RuleSetUseItem, rule: RuleSetRule) => boolean;
-type LoaderReplacer = (
+export type LoaderReplacer = (
   loader: RuleSetUseItem,
   rule: RuleSetRule
 ) => RuleSetUseItem | null;

--- a/src/webpack.ts
+++ b/src/webpack.ts
@@ -6,10 +6,50 @@
 import {
   Configuration,
   Plugin,
+  RuleSetCondition,
   RuleSetRule,
   RuleSetUse,
   RuleSetUseItem,
 } from "webpack";
+
+// https://webpack.js.org/configuration/module/#condition
+function testRuleCondition(
+  condition: RuleSetCondition,
+  filename: string
+): boolean {
+  if (typeof condition === "function") {
+    return condition(filename);
+  }
+
+  if (typeof condition === "string") {
+    return condition.indexOf(filename) === 0;
+  }
+
+  if (condition instanceof RegExp) {
+    return condition.test(filename);
+  }
+
+  if (condition instanceof Array) {
+    return condition.some((child) => testRuleCondition(child, filename));
+  }
+
+  // Object-style condition is not supported.
+  return false;
+}
+
+/**
+ * Returns whether the rule will be applied to a file with given filename.
+ * @param rule rule to test
+ * @param filename filename or filepath to test with
+ * @returns whether the rule is active for the file
+ */
+export function isRuleAppliedTo(rule: RuleSetRule, filename: string): boolean {
+  if (!rule.test) {
+    return false;
+  }
+
+  return testRuleCondition(rule.test, filename);
+}
 
 /**
  * Replace minimizer library.


### PR DESCRIPTION
# What I changed

<!-- Well written summary speeds up a review process -->

Added options to allow a user to provide a custom loader in place of `babel-loader`.

# Links

<!-- Links for PR, Issues and other resources if any -->

close #19 

# How to test

<!-- If your changes are completely testable with unit tests and you updated test files if necessary, just write "Unit tests" -->

Install `@swc/core` and `swc-loader` at `examples/basic` directory.

```sh
$ yarn add -D @swc/core swc-loader
```

Add these lines to `examples/basic/.storybook/main.js` and run Storybook.

```diff
+ managerTranspiler() {
+   return { loader: "swc-loader" }
+ }
```

# Additional contexts

<!-- if any... -->

I did not integrate SWC directly because `swc-loader` is unstable or immature, and there is little-to-zero speed gain compared to ESBuild, as far as I tested.
