### PR TITLE
Use esbuild-loader automatic loader resolution

### DIFF
--- a/src/transformers.ts
+++ b/src/transformers.ts
@@ -21,7 +21,6 @@ export const esbuildLoaderReplacer: LoaderReplacer = (loader, rule) => ({
   loader: require.resolve("esbuild-loader"),
   options: {
     target: "es2015",
-    loader: isRuleAppliedTo(rule, "foo.ts") ? "tsx" : "jsx",
   },
 });
 


### PR DESCRIPTION
# What I changed

`esbuild-loader` can now detect loaders automatically. The current setting leads to errors like `ERROR: The character ">" is not valid inside a JSX element` or `ERROR: Unexpected end of file before a closing "T" tag` 
